### PR TITLE
use dymola python bridge to run framework on windows

### DIFF
--- a/add_dymola_to_active_environment.py
+++ b/add_dymola_to_active_environment.py
@@ -1,0 +1,22 @@
+# this works on windows
+import os
+import sys
+
+# this adds dymola as package to the installation
+python_packages_path = os.path.join(os.path.dirname(sys.executable), 'Lib\\site-packages')
+
+dymola_search_path1 = os.path.join('C:\\',  'Program Files',
+                      'Dymola 2018 FD01',
+                      'Modelica',
+                      'Library',
+                      'python_interface',
+                      'dymola.egg')
+dymola_search_path2 = os.path.join('C:\\',  'Program Files',
+                      'Dymola 2018',
+                      'Modelica',
+                      'Library',
+                      'python_interface',
+                      'dymola.egg')
+
+with open(os.path.join(python_packages_path, 'dymola-python-interface.pth'), 'w') as pathfile:
+    pathfile.write(dymola_search_path2+'\n'+dymola_search_path1+'\n')

--- a/modelicares/exps/__init__.py
+++ b/modelicares/exps/__init__.py
@@ -708,7 +708,7 @@ def write_script(experiments=[(None, {}, {})], packages=[],
                                                                   'package.mo'))
                 mos.write('cd("%s");\n' % working_dir)
         mos.write('destination = "%s";\n'
-                  % (os.path.normpath(results_dir) + os.path.sep))
+                  % (os.path.normpath(results_dir)))
         mos.write('\n')
         # Sometimes Dymola opens with an error; simulate any model to clear the
         # error.
@@ -732,7 +732,7 @@ def write_script(experiments=[(None, {}, {})], packages=[],
                 mos.write('ok = %s();\n' % command)
             mos.write('if ok then\n')
             mos.write('    savelog();\n')
-            folder = str(i)
+            folder = os.path.sep+str(i)
             mos.write('    createDirectory(destination + "%s");\n' % folder)
             for result in results:
                 mos.write('    copy("%s", destination + "%s", true);\n' %


### PR DESCRIPTION
Hi,

thanks for updating this repository for python 3. I wanted to try the code on my machine and was experiencing trouble with the automated simulation execution, due to it only being implemented for linux. In this pull request I want to show a possibility to use this in windows as well. The proposed solution, might also be favourable for runtime optimization.

# why
- the current setup executes a `*.mos` file **directly** with the dymola executable. 
- this loads all user interface libraries see [stackoverflow](https://stackoverflow.com/questions/39904247/can-i-launch-dymola-without-the-gui)
- the approach is unflexible, since the specific command to launch the dymola executable varies depending on the used operating system
- the approach is doesn't allow treatment of errors during execution

# how
- Dymola ships a python interface of its own see https://github.com/RWTH-EBC/AixLib/wiki/How-to:-Dymola-Python-Interface
- Small adjustments are needed to in the `*.mos` writer

# tasks left
- clean the code. This is just a working example.

I would be happy if you would consider such a change.

